### PR TITLE
Bugfix: Enabling restic backups breaks the chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
-## [v8.1.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.4) (2023-11-17)
+## [v8.1.5](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.5) (2023-11-22)
+- Fix: Typo in the restic backup template preventing chart from being deployed
+
+## [v8.1.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.4) (2023-11-20)
 - Fix: Utilize `puppetserver` and `puppetdb` containers provided by voxpupuli and bump default versions
 
 ## [v8.1.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.3) (2023-09-24)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 8.1.4
+version: 8.1.5
 appVersion: 7.13.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/puppetserver-ca-backup-cronjob.yaml
+++ b/templates/puppetserver-ca-backup-cronjob.yaml
@@ -72,7 +72,7 @@ spec:
           volumes:
           - name: puppet-ca-storage
             persistentVolumeClaim:
-              claimName: {{ template "puppetserver.persitence.ca.claimName" . }}
+              claimName: {{ template "puppetserver.persistence.ca.claimName" . }}
           - name: puppet-puppet-storage
             persistentVolumeClaim:
               claimName: {{ template "puppetserver.persistence.puppet.claimName" . }}


### PR DESCRIPTION
Due to a typo in the volumes within the restic backup template, enabling said backups will break the chart rendering it undeployable.

Fixing the typo.